### PR TITLE
README: describe architecture and event timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Server sent event bridge for the [Libraries.io](https://libraries.io) events firehose.
 
+## Event timing
+
+The Libraries.io events firehose allows you to consume new upstream release
+events in near-realtime.
+
+The main [libraries.io dispatch
+application](https://libraries.io/github/librariesio/dispatch) polls several
+upstream repository feeds every 30 seconds. For GitHub specifically, the
+dispatch app watches the [server-sent event stream for
+GitHub](https://github.com/librariesio/github-firehose).
+
+Your new release event should show up in the libraries.io firehose in less than
+one minute, although the [GitHub Event API is delayed by five
+minutes](https://github.blog/changelog/2018-08-01-new-delay-public-events-api/).
+
 ## Development
 
 Source hosted at [GitHub](http://github.com/librariesio/firehose).


### PR DESCRIPTION
Clarify to users how long they should expect to wait between pushing a
new upstream release and seeing the event in the libraries.io firehose.